### PR TITLE
Fix scheduler integration, logging APIs, and data source testing

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -116,16 +116,12 @@ func setupRouter(db *sql.DB) *gin.Engine {
 	flowLogs := r.Group("/flow-logs", h.Auth.MustLogin())
 	{
 		flowLogs.GET("", h.Log.FlowLogList)
-		flowLogs.GET("/api", h.Log.GetFlowLogs)
-		flowLogs.GET("/api/:id", h.Log.GetFlowLogDetail)
 	}
 
 	taskLogs := r.Group("/task-logs", h.Auth.MustLogin())
 	{
 		taskLogs.GET("", h.Log.TaskLogList)
 		taskLogs.GET("/:id", h.Log.GetTaskLogDetail)
-		taskLogs.GET("/api", h.Log.GetTaskLogs)
-		taskLogs.GET("/api/:id", h.Log.GetTaskLogDetail)
 	}
 
 	// API路由
@@ -133,6 +129,12 @@ func setupRouter(db *sql.DB) *gin.Engine {
 	{
 		api.GET("/meta/mysql/:id/columns/:table", h.Meta.Columns)
 		api.POST("/datax/preview", h.DataX.ConfigPreview)
+		api.GET("/task-logs", h.Log.GetTaskLogs)
+		api.GET("/task-logs/:id", h.Log.GetTaskLogDetail)
+		api.POST("/task-logs/:id/kill", h.Log.KillTaskByLog)
+		api.GET("/flow-logs", h.Log.GetFlowLogs)
+		api.GET("/flow-logs/:id", h.Log.GetFlowLogDetail)
+		api.POST("/flow-logs/:id/kill", h.Log.KillFlowByLog)
 	}
 
 	// 工具页面

--- a/internal/database/taskflow.go
+++ b/internal/database/taskflow.go
@@ -70,10 +70,10 @@ func (d *TaskFlowDB) ListEnabled() ([]entities.TaskFlow, error) {
 
 // GetByID 根据ID获取任务流
 func (d *TaskFlowDB) GetByID(id int) (*entities.TaskFlow, error) {
-	query := `SELECT id,name,cron_expr,enabled FROM task_flows WHERE id=?`
+	query := `SELECT id,name,description,cron_expr,enabled,created_at,updated_at FROM task_flows WHERE id=?`
 
 	var flow entities.TaskFlow
-	err := db.QueryRow(query, id).Scan(&flow.ID, &flow.Name, &flow.CronExpr, &flow.Enabled)
+	err := db.QueryRow(query, id).Scan(&flow.ID, &flow.Name, &flow.Description, &flow.CronExpr, &flow.Enabled, &flow.CreatedAt, &flow.UpdatedAt)
 
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -87,11 +87,15 @@ func (d *TaskFlowDB) GetByID(id int) (*entities.TaskFlow, error) {
 
 // Create 创建任务流
 func (d *TaskFlowDB) Create(flow *entities.TaskFlow) error {
-	query := `INSERT INTO task_flows(name,cron_expr,enabled,created_by,updated_by) VALUES(?,?,?,?,?)`
+	query := `INSERT INTO task_flows(name,description,cron_expr,enabled,created_by,updated_by) VALUES(?,?,?,?,?,?)`
 
-	_, err := db.Exec(query, flow.Name, flow.CronExpr, flow.Enabled, flow.CreatedBy, flow.UpdatedBy)
+	result, err := db.Exec(query, flow.Name, flow.Description, flow.CronExpr, flow.Enabled, flow.CreatedBy, flow.UpdatedBy)
 	if err != nil {
 		return fmt.Errorf("创建任务流失败: %w", err)
+	}
+
+	if flowID, err := result.LastInsertId(); err == nil {
+		flow.ID = int(flowID)
 	}
 
 	return nil
@@ -99,9 +103,9 @@ func (d *TaskFlowDB) Create(flow *entities.TaskFlow) error {
 
 // Update 更新任务流
 func (d *TaskFlowDB) Update(flow *entities.TaskFlow) error {
-	query := `UPDATE task_flows SET name=?,cron_expr=?,enabled=?,updated_by=? WHERE id=?`
+	query := `UPDATE task_flows SET name=?,description=?,cron_expr=?,enabled=?,updated_by=? WHERE id=?`
 
-	result, err := db.Exec(query, flow.Name, flow.CronExpr, flow.Enabled, flow.UpdatedBy, flow.ID)
+	result, err := db.Exec(query, flow.Name, flow.Description, flow.CronExpr, flow.Enabled, flow.UpdatedBy, flow.ID)
 	if err != nil {
 		return fmt.Errorf("更新任务流失败: %w", err)
 	}

--- a/internal/entities/log.go
+++ b/internal/entities/log.go
@@ -40,20 +40,20 @@ type TaskExecutionLog struct {
 
 // FlowLogListResponse 表示流程日志列表响应
 type FlowLogListResponse struct {
-	Logs      []FlowExecutionLog `json:"logs"`
-	Total     int                `json:"total"`
-	Page      int                `json:"page"`
-	PageSize  int                `json:"page_size"`
-	TotalPage int                `json:"total_page"`
+	Logs       []FlowExecutionLog `json:"logs"`
+	Total      int                `json:"total"`
+	Page       int                `json:"page"`
+	PageSize   int                `json:"page_size"`
+	TotalPages int                `json:"total_pages"`
 }
 
 // TaskLogListResponse 表示任务日志列表响应
 type TaskLogListResponse struct {
-	Logs      []TaskExecutionLog `json:"logs"`
-	Total     int                `json:"total"`
-	Page      int                `json:"page"`
-	PageSize  int                `json:"page_size"`
-	TotalPage int                `json:"total_page"`
+	Logs       []TaskExecutionLog `json:"logs"`
+	Total      int                `json:"total"`
+	Page       int                `json:"page"`
+	PageSize   int                `json:"page_size"`
+	TotalPages int                `json:"total_pages"`
 }
 
 // FlowLogDetailResponse 表示流程日志详情响应

--- a/internal/handler/log.go
+++ b/internal/handler/log.go
@@ -2,9 +2,13 @@ package handler
 
 import (
 	"com.duole/datax-web-go/internal/database"
+	"com.duole/datax-web-go/internal/service"
+	"errors"
 	"github.com/gin-gonic/gin"
 	"net/http"
 	"strconv"
+	"strings"
+	"time"
 )
 
 // LogHandler 日志处理器
@@ -20,22 +24,63 @@ func (h *LogHandler) TaskLogList(c *gin.Context) {
 	c.HTML(http.StatusOK, "task_log/list.tmpl", gin.H{})
 }
 
-// GetTaskLogs 获取任务执行日志列表（支持独立任务和任务流步骤）
+// GetTaskLogs 获取任务执行日志列表
 func (h *LogHandler) GetTaskLogs(c *gin.Context) {
-	// 获取查询参数
 	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
 	pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "20"))
-	status := c.Query("status")
-	taskID := c.Query("task_id")
+	status := strings.TrimSpace(c.Query("status"))
+	executionType := strings.TrimSpace(c.Query("execution_type"))
+	taskName := strings.TrimSpace(c.Query("task_name"))
 
-	// 调用database层获取日志
-	response, err := database.GetDB().Log.GetTaskLogs(page, pageSize, taskID, status)
+	parseDate := func(val string) (*time.Time, error) {
+		if strings.TrimSpace(val) == "" {
+			return nil, nil
+		}
+		t, err := time.ParseInLocation("2006-01-02", val, time.Local)
+		if err != nil {
+			return nil, err
+		}
+		return &t, nil
+	}
+
+	dateFrom, err := parseDate(c.Query("date_from"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的开始日期"})
+		return
+	}
+
+	dateTo, err := parseDate(c.Query("date_to"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的结束日期"})
+		return
+	}
+
+	if dateTo != nil {
+		endOfDay := dateTo.Add(24*time.Hour - time.Nanosecond)
+		dateTo = &endOfDay
+	}
+
+	filters := database.TaskLogFilters{
+		Status:        status,
+		ExecutionType: executionType,
+		TaskName:      taskName,
+		DateFrom:      dateFrom,
+		DateTo:        dateTo,
+	}
+
+	result, err := database.GetDB().Log.GetTaskLogs(page, pageSize, filters)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "获取任务日志失败: " + err.Error()})
 		return
 	}
 
-	c.JSON(http.StatusOK, response)
+	c.JSON(http.StatusOK, gin.H{
+		"logs":        result.Logs,
+		"page":        result.Page,
+		"page_size":   result.PageSize,
+		"total":       result.Total,
+		"total_pages": result.TotalPages,
+	})
 }
 
 // GetTaskLogDetail 获取任务日志详情（支持JSON和HTML）
@@ -46,10 +91,9 @@ func (h *LogHandler) GetTaskLogDetail(c *gin.Context) {
 		return
 	}
 
-	// 调用database层获取日志详情
-	log, err := database.GetDB().Log.GetTaskLogDetail(id)
+	logEntry, err := database.GetDB().Log.GetTaskLogDetail(id)
 	if err != nil {
-		if err.Error() == "日志不存在" {
+		if errors.Is(err, database.ErrTaskLogNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "日志不存在"})
 		} else {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "获取日志详情失败: " + err.Error()})
@@ -57,12 +101,26 @@ func (h *LogHandler) GetTaskLogDetail(c *gin.Context) {
 		return
 	}
 
-	// 根据Accept头决定返回格式
-	if c.GetHeader("Accept") == "application/json" {
-		c.JSON(http.StatusOK, log)
-	} else {
-		c.HTML(http.StatusOK, "task_log/detail.tmpl", gin.H{"Log": log})
+	if c.GetHeader("Accept") == "application/json" || strings.HasPrefix(c.FullPath(), "/api/") {
+		c.JSON(http.StatusOK, gin.H{
+			"id":                logEntry.ID,
+			"task_id":           logEntry.TaskID,
+			"task_name":         logEntry.TaskName,
+			"status":            logEntry.Status,
+			"execution_type":    logEntry.ExecutionType,
+			"start_time":        logEntry.StartTime,
+			"end_time":          logEntry.EndTime,
+			"duration":          logEntry.Duration,
+			"flow_execution_id": logEntry.FlowExecutionID,
+			"step_id":           logEntry.StepID,
+			"step_order":        logEntry.StepOrder,
+			"content":           logEntry.LogContent,
+			"created_at":        logEntry.CreatedAt,
+		})
+		return
 	}
+
+	c.HTML(http.StatusOK, "task_log/detail.tmpl", gin.H{"Log": logEntry})
 }
 
 // FlowLogList 显示任务流日志列表页面
@@ -72,20 +130,63 @@ func (h *LogHandler) FlowLogList(c *gin.Context) {
 
 // GetFlowLogs 获取任务流日志列表
 func (h *LogHandler) GetFlowLogs(c *gin.Context) {
-	// 获取查询参数
 	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
 	pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "20"))
-	status := c.Query("status")
-	flowID := c.Query("flow_id")
+	status := strings.TrimSpace(c.Query("status"))
+	executionType := strings.TrimSpace(c.Query("execution_type"))
+	flowName := strings.TrimSpace(c.Query("flow_name"))
 
-	// 调用database层获取日志
-	response, err := database.GetDB().Log.GetFlowLogs(page, pageSize, flowID, status)
+	parseDate := func(val string) (*time.Time, error) {
+		if strings.TrimSpace(val) == "" {
+			return nil, nil
+		}
+		t, err := time.ParseInLocation("2006-01-02", val, time.Local)
+		if err != nil {
+			return nil, err
+		}
+		return &t, nil
+	}
+
+	dateFrom, err := parseDate(c.Query("date_from"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的开始日期"})
+		return
+	}
+
+	dateTo, err := parseDate(c.Query("date_to"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的结束日期"})
+		return
+	}
+
+	if dateTo != nil {
+		endOfDay := dateTo.Add(24*time.Hour - time.Nanosecond)
+		dateTo = &endOfDay
+	}
+
+	filters := database.FlowLogFilters{
+		Status:        status,
+		ExecutionType: executionType,
+		FlowName:      flowName,
+		DateFrom:      dateFrom,
+		DateTo:        dateTo,
+	}
+
+	result, err := database.GetDB().Log.GetFlowLogs(page, pageSize, filters)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "获取任务流日志失败: " + err.Error()})
 		return
 	}
 
-	c.JSON(http.StatusOK, response)
+	c.JSON(http.StatusOK, gin.H{
+		"logs": result.Logs,
+		"pagination": gin.H{
+			"current_page": result.Page,
+			"page_size":    result.PageSize,
+			"total_pages":  result.TotalPages,
+			"total":        result.Total,
+		},
+	})
 }
 
 // GetFlowLogDetail 获取任务流日志详情
@@ -96,16 +197,77 @@ func (h *LogHandler) GetFlowLogDetail(c *gin.Context) {
 		return
 	}
 
-	// 调用database层获取日志详情
 	response, err := database.GetDB().Log.GetFlowLogDetail(id)
 	if err != nil {
-		if err.Error() == "日志不存在" {
+		if errors.Is(err, database.ErrFlowLogNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "日志不存在"})
 		} else {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "获取日志详情失败: " + err.Error()})
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "获取任务流日志详情失败: " + err.Error()})
 		}
 		return
 	}
 
-	c.JSON(http.StatusOK, response)
+	c.JSON(http.StatusOK, gin.H{
+		"id":             response.Log.ID,
+		"flow_id":        response.Log.FlowID,
+		"flow_name":      response.Log.FlowName,
+		"status":         response.Log.Status,
+		"execution_type": response.Log.ExecutionType,
+		"start_time":     response.Log.StartTime,
+		"end_time":       response.Log.EndTime,
+		"duration":       response.Log.Duration,
+		"content":        response.Log.LogContent,
+	})
+}
+
+// KillTaskByLog 根据日志ID终止任务
+func (h *LogHandler) KillTaskByLog(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的日志ID"})
+		return
+	}
+
+	logEntry, err := database.GetDB().Log.GetTaskLogDetail(id)
+	if err != nil {
+		if errors.Is(err, database.ErrTaskLogNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "日志不存在"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "查询日志信息失败: " + err.Error()})
+		return
+	}
+
+	if err := service.Get().Scheduler.KillTask(logEntry.TaskID); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "任务已终止"})
+}
+
+// KillFlowByLog 根据日志ID终止任务流
+func (h *LogHandler) KillFlowByLog(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "无效的日志ID"})
+		return
+	}
+
+	response, err := database.GetDB().Log.GetFlowLogDetail(id)
+	if err != nil {
+		if errors.Is(err, database.ErrFlowLogNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "日志不存在"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "查询日志信息失败: " + err.Error()})
+		return
+	}
+
+	if err := service.Get().Scheduler.KillTaskFlow(response.Log.FlowID); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true, "message": "任务流已终止"})
 }

--- a/internal/handler/task.go
+++ b/internal/handler/task.go
@@ -247,5 +247,5 @@ func (h *TaskHandler) RunNow(c *gin.Context) {
 		}
 	}()
 
-	c.String(http.StatusOK, "任务已提交执行")
+	c.JSON(http.StatusOK, gin.H{"message": "任务已提交执行"})
 }

--- a/internal/service/scheduler.go
+++ b/internal/service/scheduler.go
@@ -453,9 +453,15 @@ func (s *Scheduler) executeFlowSteps(ctx context.Context, flowID, execID int, ex
 	for rows.Next() {
 		var step entities.TaskFlowStep
 		var stepOrder int
-		rows.Scan(&step.ID, &step.TaskID, &step.TimeoutMinutes, &stepOrder, &step.TaskName)
+		if err := rows.Scan(&step.ID, &step.TaskID, &step.TimeoutMinutes, &stepOrder, &step.TaskName); err != nil {
+			return fmt.Errorf("failed to scan task flow step: %w", err)
+		}
 		step.StepOrder = stepOrder
 		steps = append(steps, step)
+	}
+
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed to iterate task flow steps: %w", err)
 	}
 
 	// 按顺序执行所有步骤


### PR DESCRIPTION
## Summary
- Align task flow persistence with scheduler reloads and consistent JSON responses.
- Replace log queries to use the actual schema, expose API endpoints with filtering, and integrate kill operations.
- Accept JSON payloads for data source connection tests and return structured results.
- Harden scheduler step execution by checking scan errors.

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ce8cdbff908320af74093c4ff1d0d1